### PR TITLE
Update jinja2 test for atomic

### DIFF
--- a/ansible/roles/pre-ansible/tasks/main.yml
+++ b/ansible/roles/pre-ansible/tasks/main.yml
@@ -18,4 +18,4 @@
   when: s.stat.exists
 
 - include: fedora-dnf.yml
-  when: os_version.stdout|int >= 22 and 'Fedora' in distro.stdout and not is_atomic
+  when: os_version.stdout|int >= 22 and 'Fedora' in distro.stdout and is_atomic is not defined


### PR DESCRIPTION
This `is_atomic` fact is not set if /run/ostree-booted doesn't exist, rather than being set to false. The `set_fact` task will show as Skipped for non-Atomic hosts.

The test to run the fedora-dnf tasks needs to check for that fact not existing rather than being false.
