### PR TITLE
add HOME env variable for kube-addons service

### DIFF
--- a/ansible/roles/kubernetes-addons/templates/kube-addons.service.j2
+++ b/ansible/roles/kubernetes-addons/templates/kube-addons.service.j2
@@ -3,6 +3,7 @@ Description=Kubernetes Addon Object Manager
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
+Environment=HOME=/root
 Environment="TOKEN_DIR={{ kube_token_dir }}"
 Environment="KUBECTL_BIN={{ bin_dir }}/kubectl"
 Environment="KUBERNETES_MASTER_NAME={{ groups['masters'][0] }}"


### PR DESCRIPTION
Implements upstream change https://github.com/kubernetes/kubernetes/pull/23975, which fixes https://github.com/kubernetes/kubernetes/issues/23973.
